### PR TITLE
Umount ISO image before raising SystemExit(1)

### DIFF
--- a/fedup.py
+++ b/fedup.py
@@ -114,6 +114,7 @@ def main(args):
             print _("The '%s' repo was rejected by yum as invalid.") % args.instrepo
             if args.iso:
                 print _("The given ISO probably isn't an install DVD image.")
+                fedup.media.umount(args.device.mnt)
             elif args.device:
                 print _("The media doesn't contain a valid install DVD image.")
         else:


### PR DESCRIPTION
When ISO file is not the required DVD install, we should umount the mount point
before raising the exception.

Fix bug https://bugzilla.redhat.com/show_bug.cgi?id=981076
