### PR TITLE
Make sure that /etc/crypttab is in the initrd if the disk is encrypted

### DIFF
--- a/fedup/boot.py
+++ b/fedup/boot.py
@@ -19,6 +19,7 @@
 
 from subprocess import check_output, PIPE, Popen, CalledProcessError
 from shutil import copyfileobj
+import os
 
 kernelprefix = "/boot/vmlinuz-"
 
@@ -74,6 +75,16 @@ def need_mdadmconf():
             line = line.strip()
             if line and not line.startswith("#"):
                 # Hey there's actual *data* in here! WE MIGHT NEED THIS!!
+                return True
+    except IOError:
+        pass
+    return False
+
+def need_crypttab():
+    '''Does this system need /etc/crypttab to boot?'''
+    try:
+        for line in os.listdir('/dev/mapper'):
+            if line.startswith('luks-'):
                 return True
     except IOError:
         pass

--- a/fedup/sysprep.py
+++ b/fedup/sysprep.py
@@ -145,6 +145,12 @@ def prep_boot(kernel, initrd):
         log.info("appending /etc/mdadm.conf to initrd")
         boot.initramfs_append_files(initrd, "/etc/mdadm.conf")
 
+    # check if the system is encrypted and need /etc/cryppttab
+    # to be present for systemd to mount it
+    if boot.need_crypttab():
+        log.info("appending /etc/crypttab to initrd")
+        boot.initramfs_append_files(initrd, "/etc/crypttab")
+
     # look for updates, and add them to initrd if found
     updates = []
     try:


### PR DESCRIPTION
systemd-cryptsetup-generator requires /etc/crypttab in the initrd in
order to generate the disk unit to mount all partitions.

See https://bugzilla.redhat.com/show_bug.cgi?id=1012899
