### PR TITLE
Change the python-devel BuildRequires to python-libs

### DIFF
--- a/fedup.spec
+++ b/fedup.spec
@@ -12,7 +12,7 @@ Source0:        https://github.com/downloads/wgwoods/fedup/%{name}-%{version}.ta
 Requires:       systemd >= systemd-44-23.fc17
 Requires:       grubby
 
-BuildRequires:  python2-devel
+BuildRequires:  python-libs
 BuildRequires:  systemd-devel
 BuildRequires:  asciidoc
 BuildArch:      noarch


### PR DESCRIPTION
We want a BuildRequires for the distutils module, since it's not in
the regular python package (surprise!), but python-libs is where it
actually lives. python-devel is more for Python/C stuff, and we don't
have any of that.
