### PR TITLE
Fix the systemd Requires: line.

### DIFF
--- a/fedup.spec
+++ b/fedup.spec
@@ -9,7 +9,7 @@ Source0:        https://github.com/downloads/wgwoods/fedup/%{name}-%{version}.ta
 
 # Require updates to various packages where necessary to fix bugs.
 # Bug #910326
-Requires:       systemd >= systemd-44-23.fc17
+Requires:       systemd >= 44-23.fc17
 Requires:       grubby
 
 BuildRequires:  python-libs


### PR DESCRIPTION
Only use the version number in the right hand side of the Requires
instead of NVR.
