### PR TITLE
Support symlinks with --device.

### DIFF
--- a/fedup/commandline.py
+++ b/fedup/commandline.py
@@ -156,6 +156,10 @@ def device_or_mnt(arg):
     if arg == 'auto':
         localmedia = media.find()
     else:
+        # If the arg specified is a symlink (e.g., /dev/cdrom), follow it
+        # to the real device file
+        if os.path.islink(arg):
+            arg = os.path.realpath(arg)
         localmedia = [m for m in media.find() if arg in (m.dev, m.mnt)]
 
     if len(localmedia) == 1:


### PR DESCRIPTION
Most people trying to upgrade with a DVD in the drive are probably going
to use either --device=auto or --device=/dev/cdrom, so it might be nice
if the latter worked.
