### PR TITLE
Run realpath on --device arguments.

### DIFF
--- a/fedup/commandline.py
+++ b/fedup/commandline.py
@@ -156,6 +156,9 @@ def device_or_mnt(arg):
     if arg == 'auto':
         localmedia = media.find()
     else:
+        # Canonicalize the device or mountpoint argument
+        arg = os.path.realpath(arg)
+
         localmedia = [m for m in media.find() if arg in (m.dev, m.mnt)]
 
     if len(localmedia) == 1:


### PR DESCRIPTION
This way arguments like /dev/cdrom (a symlink), /mnt/ (trailing slash),
or ./../path/../..////../media/../srv/install (madness) will work as
expected.
