### PR TITLE
Extend the --product warning message

### DIFF
--- a/fedup/commandline.py
+++ b/fedup/commandline.py
@@ -150,7 +150,7 @@ def parse_args(gui=False):
             if int(version) == 20 or args.network in ('21', '22', 'rawhide'):
                 p.error(fedora_next_error)
         elif args.product == 'nonproduct':
-            args.add_install.append('fedora-release-standard')
+            args.add_install.append('fedora-release-nonproduct')
         else:
             args.add_install.append('@^%s-product-environment' % args.product)
 


### PR DESCRIPTION
Make sure that users know that Workstation is GNOME and that the $PRODUCT choices may install new packages.

Rename fedora-release-standard to fedora-release-nonproduct:
It was properly obsoleted in Fedora, so either will work, but we may as well use the correct current name here.
