### PR TITLE
use distro-sync approach to populate package set

### DIFF
--- a/fedup/download.py
+++ b/fedup/download.py
@@ -22,6 +22,7 @@ import yum
 import time
 import struct
 import logging
+import sys
 from .callback import BaseTsCallback
 from .treeinfo import Treeinfo, TreeinfoError
 from .conf import Config
@@ -29,6 +30,9 @@ from yum.Errors import YumBaseError, InstallError
 from yum.parser import varReplace
 from yum.constants import TS_REMOVE_STATES, TS_TRUEINSTALL
 from yum.misc import gpgme
+# This is ugly, but we need distroSyncPkgs() and it's only in YumBaseCli
+sys.path.insert(0, '/usr/share/yum-cli')
+from cli import YumBaseCli
 
 enabled_plugins = ['blacklist', 'whiteout']
 disabled_plugins = ['rpm-warm-cache', 'remove-with-leaves', 'presto',
@@ -83,7 +87,7 @@ def list_keyring(gpgdir):
             for k in yum.misc.return_keyids_from_pubring(gpgdir)]
 
 
-class UpgradeDownloader(yum.YumBase):
+class UpgradeDownloader(YumBaseCli):
     '''Yum-based downloader class. Based roughly on AnacondaYum.'''
     def __init__(self, version=None, cachedir=cachedir, cacheonly=False):
         # TODO: special handling for version='test' where we just synthesize
@@ -254,7 +258,7 @@ class UpgradeDownloader(yum.YumBase):
         log.info("looking for updates")
         self.dsCallback = callback
         # get updates for everything on the system
-        self.update()
+        self.distroSyncPkgs([])
         # add some extra things to the upgrade transaction
         for pat in add_install:
             log.info("adding '%s' to upgrade", pat)


### PR DESCRIPTION
This is more of an example / PoC, really. It fixes https://github.com/wgwoods/fedup/issues/21 .

I noticed that fedup already actually hacks things up so it can import from yum-cli in `textoutput.py`, and when you've got an ugly hack, what you want to do is spread it out all through your codebase, right?

So by using the same ugly hack in `download.py` we can do distro-sync. This looks small but inheriting from YumBaseCli instead of YumBase could have other consequences, we'd need to check carefully what YumBaseCli overrides and see if any of it would affect fedup's behaviour. (No, we can't inherit from `YumBase` then `YumBaseCli` so we get extra methods from `YumBaseCli` but retain `YumBase`'s behaviour for ones they share; I tried, Python doesn't let you). But this does work in a test for me, upgrading a clean F20 desktop install to F21 Workstation.

I didn't make it switchable between 'update' and 'distro-sync' behaviour because it keeps the diff smaller for discussion, and frankly, I still think it's correct to _only_ do 'distro-sync' in fedup. But that of course can be discussed.
